### PR TITLE
Reduce steps for redirect URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,8 @@ Your native application registration should include the following information:
 1. Find the assignment for the scopes `public static string[] Scopes` and replace the scopes with those you created in Step 4.
 
 #### [OPTIONAL] Step 6a: Configure the iOS project with your app's return URI
- 1. Open the `UserDetailsClient.iOS\AppDelegate.cs` file.
- 2. Locate the `App.PCA.RedirectUri` assignment, and change it to assign the string `"msal<Application Id>://auth"` where `<Application Id>` is the identifier you copied in step 2
- 3. Open the `UserDetailsClient.iOS\info.plist` file in a text editor (opening it in Visual Studio won't work for this step as you need to edit the text)
- 4. In the URL types, section, add an entry for the authorization schema used in your redirectUri.
+ 1. Open the `UserDetailsClient.iOS\info.plist` file in a text editor (opening it in Visual Studio won't work for this step as you need to edit the text)
+ 1. In the URL types, section, add an entry for the authorization schema used in your redirectUri.
  ```xml
  <key>CFBundleURLSchemes</key>
  <array>
@@ -85,10 +83,8 @@ Your native application registration should include the following information:
  
  #### [OPTIONAL] Step 6b: Configure the Android project with your app's return URI
  
- 1. Open the `UserDetailsClient.Droid\MainActivity.cs` file.
- 2. Locate the `App.PCA.RedirectUri` assignment, and change it to assign the string `"msal<Application Id>://auth"` where `<Application Id>` is the identifier you copied in step 2
- 3. Open the `UserDetailsClient.Droid\Properties\AndroidManifest.xml`
- 4. Add or modify the `<application>` element as in the following
+ 1. Open the `UserDetailsClient.Droid\Properties\AndroidManifest.xml`
+ 1. Add or modify the `<application>` element as in the following
  ```xml
 <application>
   <activity android:name="microsoft.identity.client.BrowserTabActivity">

--- a/UserDetailsClient/UserDetailsClient.Droid/MainActivity.cs
+++ b/UserDetailsClient/UserDetailsClient.Droid/MainActivity.cs
@@ -20,7 +20,6 @@ namespace UserDetailsClient.Droid
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
             LoadApplication(new App());
-            App.PCA.RedirectUri = "msal90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6://auth";
             App.UiParent = new UIParent(Xamarin.Forms.Forms.Context as Activity);           
         }
 

--- a/UserDetailsClient/UserDetailsClient.iOS/AppDelegate.cs
+++ b/UserDetailsClient/UserDetailsClient.iOS/AppDelegate.cs
@@ -25,7 +25,6 @@ namespace UserDetailsClient.iOS
         {
             global::Xamarin.Forms.Forms.Init();
             LoadApplication(new App());
-            App.PCA.RedirectUri = "msal90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6://auth";
             return base.FinishedLaunching(app, options);            
         }
 

--- a/UserDetailsClient/UserDetailsClient/App.cs
+++ b/UserDetailsClient/UserDetailsClient/App.cs
@@ -35,6 +35,7 @@ namespace UserDetailsClient
         {
             // default redirectURI; each platform specific project will have to override it with its own
             PCA = new PublicClientApplication(ClientID, Authority);
+            PCA.RedirectUri = $"msal{ClientID}://auth";
                         
             MainPage = new NavigationPage(new MainPage());        
         }


### PR DESCRIPTION
Automatically set the RedirectURI for the PublicClientApplication. This removes an extra step for Android and another for iOS. 