### PR TITLE
Optional PR: Fix threading issue w/webview

### DIFF
--- a/UserDetailsClient/UserDetailsClient.Core/MainPage.xaml.cs
+++ b/UserDetailsClient/UserDetailsClient.Core/MainPage.xaml.cs
@@ -54,19 +54,12 @@ namespace UserDetailsClient.Core
 
         private IUser GetUserByPolicy(IEnumerable<IUser> users, string policy)
         {
-            if (users != null)
+            foreach (var user in users)
             {
-                IUser[] userArray = users.ToArray();
-                IUser currentUser = null;
-                for (int i = 0; i < userArray.Length; i++)
-                {
-                    string identifier = userArray[i].Identifier;
-                    string userIdentifier = identifier.Split('.')[0];
-                    if (userIdentifier.EndsWith(policy.ToLower()))
-                    { currentUser = userArray[i]; }
-                }
-                return currentUser;
+                string userIdentifier = user.Identifier.Split('.')[0];
+                if (userIdentifier.EndsWith(policy.ToLower())) return user;
             }
+
             return null;
         }
 


### PR DESCRIPTION
Remove code in OnAppearing()
Fix GetUserByPolicy to return user w/policy

**Tested with:**
>Android device (embedded webview w/local build)
>iOS simulator (embedded webview w/local build)
w/Facebook, Google, & Microsoft Accounts ([Twitter does not work](https://github.com/Azure-Samples/active-directory-b2c-xamarin-native/issues/56))

**FYI:** Sign-out is not implemented and does not clear the cache. Once the MSAL cache changes are done, we need to update the sample to use the cache correctly. Right now, if you already did a successful AT with one account and want to sign in with a different account, you will need to uninstall the app on the device first, otherwise you will get an `MsalServiceException` that the client identifier does not match. 