### PR TITLE
Fixes for URLs to redirect to b2clogin.com for Azure Active Directory…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ You can also modify the sample to use your own Azure AD B2C tenant.  First, you'
 
 This sample uses three types of policies: a unified sign-up/sign-in policy & a profile editing policy.  Create one policy of each type by following [the instructions here](https://azure.microsoft.com/documentation/articles/active-directory-b2c-reference-policies).  You may choose to include as many or as few identity providers as you wish.
 
+- *IMPORTANT*: When setting up your identity providers, be sure to [set the redirect URLs](https://docs.microsoft.com/en-us/azure/active-directory-b2c/b2clogin) to use `b2clogin.com`.
+
 If you already have existing policies in your Azure AD B2C tenant, feel free to re-use those.  No need to create new ones just for this sample.
 
 ### [OPTIONAL] Step 4: Create your own Web API
@@ -65,6 +67,7 @@ Your native application registration should include the following information:
 1. Open the solution in Visual Studio.
 1. Open the `UserDetailsClient\App.cs` file.
 1. Find the assignment for `public static string Tenant` and replace the value with your tenant name.
+1. Find the assignment for `public static string TentantRedirectUrl` and replace the value with your tenant redirect url. In the past, `login.microsoftonline.com` was used, now you should be using `b2clogin.com`. For more information on changing redirect URL's [see here](https://docs.microsoft.com/en-us/azure/active-directory-b2c/b2clogin).
 1. Find the assignment for `public static string ClientID` and replace the value with the Application ID from Step 5.
 1. Find the assignment for each of the policies `public static string PolicyX` and replace the names of the policies you created in Step 3.
 1. Find the assignment for the scopes `public static string[] Scopes` and replace the scopes with those you created in Step 4.

--- a/UserDetailsClient/UserDetailsClient.Core/App.cs
+++ b/UserDetailsClient/UserDetailsClient.Core/App.cs
@@ -11,7 +11,7 @@ namespace UserDetailsClient.Core
 
         // Azure AD B2C Coordinates
         public static string Tenant = "fabrikamb2c.onmicrosoft.com";
-        public static string TentantRedirectUrl = "login.microsoftonline.com";
+        public static string AzureADB2CHostname = "login.microsoftonline.com";
         public static string ClientID = "90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6";
         public static string PolicySignUpSignIn = "b2c_1_susi";
         public static string PolicyEditProfile = "b2c_1_edit_profile";
@@ -20,7 +20,7 @@ namespace UserDetailsClient.Core
         public static string[] Scopes = { "https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read" };
         public static string ApiEndpoint = "https://fabrikamb2chello.azurewebsites.net/hello";
 
-        public static string AuthorityBase = $"https://{TentantRedirectUrl}/tfp/{Tenant}/";
+        public static string AuthorityBase = $"https://{AzureADB2CHostname}/tfp/{Tenant}/";
         public static string Authority = $"{AuthorityBase}{PolicySignUpSignIn}";
         public static string AuthorityEditProfile = $"{AuthorityBase}{PolicyEditProfile}";
         public static string AuthorityPasswordReset = $"{AuthorityBase}{PolicyResetPassword}";

--- a/UserDetailsClient/UserDetailsClient.Core/App.cs
+++ b/UserDetailsClient/UserDetailsClient.Core/App.cs
@@ -11,6 +11,7 @@ namespace UserDetailsClient.Core
 
         // Azure AD B2C Coordinates
         public static string Tenant = "fabrikamb2c.onmicrosoft.com";
+        public static string TentantRedirectUrl = "login.microsoftonline.com";
         public static string ClientID = "90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6";
         public static string PolicySignUpSignIn = "b2c_1_susi";
         public static string PolicyEditProfile = "b2c_1_edit_profile";
@@ -19,7 +20,7 @@ namespace UserDetailsClient.Core
         public static string[] Scopes = { "https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read" };
         public static string ApiEndpoint = "https://fabrikamb2chello.azurewebsites.net/hello";
 
-        public static string AuthorityBase = $"https://login.microsoftonline.com/tfp/{Tenant}/";
+        public static string AuthorityBase = $"https://{TentantRedirectUrl}/tfp/{Tenant}/";
         public static string Authority = $"{AuthorityBase}{PolicySignUpSignIn}";
         public static string AuthorityEditProfile = $"{AuthorityBase}{PolicyEditProfile}";
         public static string AuthorityPasswordReset = $"{AuthorityBase}{PolicyResetPassword}";


### PR DESCRIPTION
… B2C. Currently the demo uses the old redirect to login.microsoftonline.com which causes issues.